### PR TITLE
Exclude test_head_bucket_usage

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -1094,6 +1094,7 @@ def test_account_usage():
 
 @pytest.mark.fails_on_aws
 @pytest.mark.fails_on_dbstore
+@pytest.mark.fails_on_cloudscale
 def test_head_bucket_usage():
     # boto3.set_stream_logger(name='botocore')
     client = get_client()


### PR DESCRIPTION
`test_head_bucket_usage` currently fails against our setup due to issues with regards to the `X-RGW-Quota-Bucket-Objects` header, so we tag it with `fails_on_cloudscale` for now, for it to be skipped by our CI